### PR TITLE
Multi route socket

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+*.bak
 /target
 /classes
 /checkouts

--- a/project.clj
+++ b/project.clj
@@ -12,6 +12,8 @@
                  [ring/ring-core "1.4.0"]
                  [ring/ring-defaults "0.1.5"]
                  [ring/ring-json "0.4.0"]
+                 [com.cognitect/transit-clj "0.8.285"]
+                 [com.cognitect/transit-cljs "0.8.225"]
                  [buddy/buddy-auth "0.6.2"]
                  [slingshot "0.12.2"]
                  [compojure "1.4.0"]

--- a/project.clj
+++ b/project.clj
@@ -5,10 +5,10 @@
             :url "http://www.eclipse.org/legal/epl-v10.html"}
 
   :dependencies [[org.clojure/clojure "1.7.0"]
-                 [org.clojure/clojurescript "1.7.48"]
-                 [org.clojure/core.async "0.1.346.0-17112a-alpha"]
+                 [org.clojure/clojurescript "1.7.170"]
+                 [org.clojure/core.async "0.2.371"]
                  [org.clojure/tools.namespace "0.2.11"]
-                 [org.clojure/tools.reader "0.10.0-alpha1"]
+                 [org.clojure/tools.reader "1.0.0-alpha1"]
                  [ring/ring-core "1.4.0"]
                  [ring/ring-defaults "0.1.5"]
                  [ring/ring-json "0.4.0"]
@@ -26,7 +26,7 @@
 
   :target-path "target/%s"
 
-  :plugins [[lein-cljsbuild "1.1.0"]]
+  :plugins [[lein-cljsbuild "1.1.1"]]
 
   :cljsbuild { 
     :builds {:dev { :source-paths ["src/cljs"]

--- a/src/clj/streamhub/core.clj
+++ b/src/clj/streamhub/core.clj
@@ -2,7 +2,7 @@
   (:require [environ.core]
             [clojure.tools.reader.edn :as edn]
             [streamhub.app :refer [App start-app! start-dev!]]
-            [streamhub.serve :refer [gen-handler start-server stop-server]]
+            [streamhub.serve :refer [gen-clients-state gen-handler start-server stop-server]]
             [streamhub.stream :refer [gen-streams-state gen-publisher gen-stream
                                       add-stream! start-stream! publish-to-stream!]])
   (:gen-class))
@@ -18,7 +18,8 @@
                (map #(vector (keyword (apply str (drop-last 4 (subs (str %) 1))))
                              (edn/read-string (env %))))
                (into {})))
-   :!streams (gen-streams-state)})
+   :!streams (gen-streams-state)
+   :!clients (gen-clients-state)})
 
 (defn make-stream-from-config [!streams stream]
   (let [md (stream :metadata)

--- a/src/clj/streamhub/stream.clj
+++ b/src/clj/streamhub/stream.clj
@@ -16,7 +16,7 @@
   (start! [this chan]
     (go-loop []
       (when-let [data (<! (config :chan))]
-        (>! chan)
+        (>! chan data)
         (recur))))
   (stop! [this start-val]
     (async/close! (config :chan))))
@@ -36,8 +36,7 @@
 
 (deftype TimePublisher [config]
   StreamPublisher
-  (help [this] {:interval "Time in miliseconds to wait between sending time events"
-                :event-fn "Function to execute when time event is initiated"})
+  (help [this] {:interval "Time in miliseconds to wait between sending time events"})
   (start! [this chan]
     (let [interval (get config :interval 1000)]
       (go-loop []
@@ -132,3 +131,6 @@
     (doseq [pub (stream :publishers)] (close-publisher! !streams uuid (first pub)))
     (swap! !streams dissoc uuid)
     (doseq [chan (select-values stream [:chan :go-ch])] (async/close! chan))))
+
+(defn get-stream-id-by-ref-id [!streams ref-id]
+  (some #(when (= ((second %) :ref-id)) (first %)) @!streams))

--- a/src/cljs/streamhub/main.cljs
+++ b/src/cljs/streamhub/main.cljs
@@ -1,3 +1,5 @@
-(ns streamhub.main)
+(ns streamhub.main
+  (:require [cognitect.transit :as transit]))
 
-(js/alert "Streamhub main js loaded!")
+(enable-console-print!)
+(println "Streamhub main js loaded!")


### PR DESCRIPTION
Rather than support a single stream per socket approach we can instead use the same websocket for multiple concurrent data-streams.  This commit does so by adding the concept of a `client` which essentially an I/O wrapper around the websocket.  The client sets up three dedicated communication channels, one for stream subscriptions, one for stream publications, and another for "control" messages, which can be thought of as commands or queries to/from the client/server (yes, that means the server can issue commands to clients as well).
